### PR TITLE
get validationMessages from dist/locale/fa

### DIFF
--- a/modules/nuxt-form-generator/components/form-generator.vue
+++ b/modules/nuxt-form-generator/components/form-generator.vue
@@ -185,6 +185,7 @@
                   :name="field.model"
                   :field="field"
                   :minimal="minimal"
+                  :data-vv-as="field.label"
                 ></component>
                 <component
                   v-else
@@ -199,6 +200,7 @@
                   :name="field.model"
                   :field="field"
                   :minimal="minimal"
+                  :data-vv-as="field.label"
                 ></component>
               </template>
             </div>

--- a/modules/nuxt-form-generator/components/v-form-generator.vue
+++ b/modules/nuxt-form-generator/components/v-form-generator.vue
@@ -89,6 +89,7 @@
           :error-messages="errors.collect(field.model)"
           :name="field.model"
           :field="field"
+          :data-vv-as="field.label"
         ></component>
         <component
           v-else
@@ -102,6 +103,7 @@
           :error-messages="errors.collect(field.model)"
           :name="field.model"
           :field="field"
+          :data-vv-as="field.label"
         ></component>
       </template>
     </div>

--- a/modules/nuxt-validate/plugin.js
+++ b/modules/nuxt-validate/plugin.js
@@ -1,26 +1,7 @@
 import Vue from 'vue'
 import VeeValidate, { Validator } from 'vee-validate'
-const dictionary = {
-  en: {
-    messages: {
-      required: 'this field is required'
-    }
-  },
-  fa: {
-    messages: {
-      required: 'وارد کردن این فیلد اجباری میباشد.',
-      mobile: 'فرمت موبایل صحیح نمی باشد.',
-      email: 'فرمت ایمیل صحیح نمی باشد.',
-      nationalCode: 'کد ملی معتبر نمی باشد.',
-      phone: 'فرمت شماره تلفن صحیح نمی باشد.',
-      postalCode: 'کد پستی معتبر نمی باشد.',
-      number: 'از اعداد انگلیسی استفاده کنید',
-      digits: 'از اعداد انگلیسی استفاده کنید',
-      confirmed: 'فیلد ها مشابه یکدیگر نیستند'
-    }
-  }
-}
-Validator.localize(dictionary)
+import validationMessages from 'vee-validate/dist/locale/fa';
+import VueI18n from 'vue-i18n';
 
 Validator.extend('mobile', {
   validate(value) {
@@ -76,6 +57,15 @@ Validator.extend('postalCode', {
     return postalCode ? true : false
   }
 })
+
+Vue.use(VueI18n);
+const i18n = new VueI18n();
+i18n.locale = "fa"; // set a default locale 
+
 Vue.use(VeeValidate, {
-  locale: 'fa'
+  i18nRootKey: 'validations', // customize the root path for validation messages.
+  i18n,
+  dictionary: {
+    fa: validationMessages
+  }
 })


### PR DESCRIPTION
پیام های خطا از 
dist/locale/fa
خوانده شود. در اینصورت با اضافه کردن سایر 
error rule
مانند حداقل و حداکثر کاراکتر نیازی به تغییر دیکشنری خطا نیست